### PR TITLE
no_std support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,18 @@ jobs:
         command: check
         args: --all --bins --examples
 
+    - name: check no_std
+      uses: actions-rs/cargo@v1
+      with:
+        command: check
+        args: --no-default-features
+
+    - name: check alloc
+      uses: actions-rs/cargo@v1
+      with:
+        command: check
+        args: --no-default-features --features alloc
+
     - name: check unstable
       uses: actions-rs/cargo@v1
       with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ authors = [
 ]
 
 [features]
+default = ["std"]
+std = []
+alloc = []
 
 [dependencies]
 


### PR DESCRIPTION
Thank you for creating this! I'm in the process of porting some no_std blocking code to async and needed to make some small modifications to this crate to do so.

- Add support for no_std when the std feature is not enabled
- Enable std by default
- Add an alloc feature to pull in the alloc crate for `Vec` impls when using no_std + alloc