### PR TITLE
add the async `Iterator::filter` method

### DIFF
--- a/src/iter/filter.rs
+++ b/src/iter/filter.rs
@@ -42,10 +42,7 @@ where
     I: crate::Iterator,
     P: async FnMut(&I::Item) -> bool,
 {
-    pub(crate) fn new(stream: I, predicate: P) -> Self {
-        Self {
-            iter: stream,
-            predicate,
-        }
+    pub(crate) fn new(iter: I, predicate: P) -> Self {
+        Self { iter, predicate }
     }
 }

--- a/src/iter/filter.rs
+++ b/src/iter/filter.rs
@@ -1,0 +1,51 @@
+/// An async iterator that filters the elements of `iter` with `predicate`.
+///
+/// This `struct` is created by the [`filter`] method on [`Iterator`]. See its
+/// documentation for more.
+///
+/// [`filter`]: crate::Iterator::filter
+/// [`Iterator`]: crate::Iterator
+#[derive(Debug)]
+pub struct Filter<I, P>
+where
+    I: crate::Iterator,
+    P: async FnMut(&I::Item) -> bool,
+{
+    iter: I,
+    predicate: P,
+}
+
+impl<I, P> crate::Iterator for Filter<I, P>
+where
+    I: crate::Iterator,
+    P: async FnMut(&I::Item) -> bool,
+{
+    type Item = I::Item;
+
+    async fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let item = self.iter.next().await?;
+            if (self.predicate)(&item).await {
+                return Some(item);
+            }
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (_, upper) = self.iter.size_hint();
+        (0, upper) // can't know a lower bound, due to the predicate
+    }
+}
+
+impl<I, P> Filter<I, P>
+where
+    I: crate::Iterator,
+    P: async FnMut(&I::Item) -> bool,
+{
+    pub(crate) fn new(stream: I, predicate: P) -> Self {
+        Self {
+            iter: stream,
+            predicate,
+        }
+    }
+}

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -1,7 +1,9 @@
+mod filter;
 mod lend;
 mod lend_mut;
 mod map;
 
+pub use filter::Filter;
 pub use lend::Lend;
 pub use lend_mut::LendMut;
 pub use map::Map;
@@ -72,57 +74,5 @@ pub trait Iterator {
         Self: Sized,
     {
         LendMut::new(self)
-    }
-}
-
-/// An async iterator that filters the elements of `iter` with `predicate`.
-///
-/// This `struct` is created by the [`filter`] method on [`Iterator`]. See its
-/// documentation for more.
-///
-/// [`filter`]: crate::Iterator::filter
-/// [`Iterator`]: crate::Iterator
-#[derive(Debug)]
-pub struct Filter<I, P>
-where
-    I: crate::Iterator,
-    P: async FnMut(&I::Item) -> bool,
-{
-    iter: I,
-    predicate: P,
-}
-
-impl<I, P> crate::Iterator for Filter<I, P>
-where
-    I: crate::Iterator,
-    P: async FnMut(&I::Item) -> bool,
-{
-    type Item = I::Item;
-
-    async fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            let item = self.iter.next().await?;
-            if (self.predicate)(&item).await {
-                return Some(item);
-            }
-        }
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        let (_, upper) = self.iter.size_hint();
-        (0, upper) // can't know a lower bound, due to the predicate
-    }
-}
-
-impl<I, P> Filter<I, P>
-where
-    I: crate::Iterator,
-    P: async FnMut(&I::Item) -> bool,
-{
-    pub(crate) fn new(stream: I, predicate: P) -> Self {
-        Self {
-            iter: stream,
-            predicate,
-        }
     }
 }

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -33,6 +33,17 @@ pub trait Iterator {
         Map::new(self, f)
     }
 
+    /// Creates an iterator which uses a closure to determine if an element should be yielded.
+    #[must_use = "iterators do nothing unless iterated over"]
+    fn filter<P>(self, predicate: P) -> Filter<Self, P>
+    where
+        P: async FnMut(&Self::Item) -> bool,
+        // P: FnMut(&Self::Item) -> bool,
+        Self: Sized,
+    {
+        Filter::new(self, predicate)
+    }
+
     /// Transforms an iterator into a collection.
     #[must_use = "if you really need to exhaust the iterator, consider `.for_each(drop)` instead"]
     async fn collect<B: FromIterator<Self::Item>>(self) -> B
@@ -61,5 +72,57 @@ pub trait Iterator {
         Self: Sized,
     {
         LendMut::new(self)
+    }
+}
+
+/// An async iterator that filters the elements of `iter` with `predicate`.
+///
+/// This `struct` is created by the [`filter`] method on [`Iterator`]. See its
+/// documentation for more.
+///
+/// [`filter`]: crate::Iterator::filter
+/// [`Iterator`]: crate::Iterator
+#[derive(Debug)]
+pub struct Filter<I, P>
+where
+    I: crate::Iterator,
+    P: async FnMut(&I::Item) -> bool,
+{
+    iter: I,
+    predicate: P,
+}
+
+impl<I, P> crate::Iterator for Filter<I, P>
+where
+    I: crate::Iterator,
+    P: async FnMut(&I::Item) -> bool,
+{
+    type Item = I::Item;
+
+    async fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let item = self.iter.next().await?;
+            if (self.predicate)(&item).await {
+                return Some(item);
+            }
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (_, upper) = self.iter.size_hint();
+        (0, upper) // can't know a lower bound, due to the predicate
+    }
+}
+
+impl<I, P> Filter<I, P>
+where
+    I: crate::Iterator,
+    P: async FnMut(&I::Item) -> bool,
+{
+    pub(crate) fn new(stream: I, predicate: P) -> Self {
+        Self {
+            iter: stream,
+            predicate,
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,9 +18,8 @@
 //! the traits, use `async_trait`.
 //!
 #![cfg_attr(not(feature = "std"), no_std)]
-#![allow(incomplete_features)]
-#![feature(return_position_impl_trait_in_trait)]
-#![feature(async_fn_in_trait)]
+#![allow(async_fn_in_trait)]
+#![feature(async_closure)]
 #![forbid(unsafe_code, future_incompatible)]
 #![deny(missing_debug_implementations, nonstandard_style)]
 #![warn(missing_docs)]


### PR DESCRIPTION
This adds an async closure-based `filter` method. It compiles on the latest nightly, but R-A doesn't like it one bit yet so marking this as a draft PR. This does show that the we can correctly implement async closure-based APIs using an AFIT-based async `Iterator` trait.